### PR TITLE
Update workflow to use v3 actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
     name: Build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache west modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-zephyr-modules
         with:
@@ -48,7 +48,7 @@ jobs:
         run: cp build/zephyr/zmk.uf2 cradio_left_nice_nano_v2.uf2
 
       - name: Archive (Cradio/Sweep Left)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-zmk-sweep
           path: cradio_left_nice_nano_v2.uf2
@@ -63,7 +63,7 @@ jobs:
         run: cp build/zephyr/zmk.uf2 cradio_right_nice_nano_v2.uf2
 
       - name: Archive (Cradio/Sweep Right)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-zmk-sweep
           path: cradio_right_nice_nano_v2.uf2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Cache west modules
         uses: actions/cache@v2
         env:
@@ -27,30 +28,40 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
       - name: West Init
         run: west init -l config
+
       - name: West Update
         run: west update
+
       - name: West Zephyr export
         run: west zephyr-export
+
       - name: West Build (Cradio/Sweep Left)
         run: west build -s zmk/app -b nice_nano_v2 -- -DSHIELD=cradio_left -DZMK_CONFIG="${GITHUB_WORKSPACE}/config"
+
       - name: Cradio/Sweep Left Kconfig file
         run: cat build/zephyr/.config | grep -v "^#" | grep -v "^$"
+
       - name: Rename zmk.uf2
         run: cp build/zephyr/zmk.uf2 cradio_left_nice_nano_v2.uf2
+
       - name: Archive (Cradio/Sweep Left)
         uses: actions/upload-artifact@v2
         with:
           name: firmware-zmk-sweep
           path: cradio_left_nice_nano_v2.uf2
+
       - name: West Build (Cradio/Sweep Right)
         run: west build --pristine -s zmk/app -b nice_nano_v2 -- -DSHIELD=cradio_right -DZMK_CONFIG="${GITHUB_WORKSPACE}/config"
 
       - name: Cradio/Sweep Right Kconfig file
         run: cat build/zephyr/.config | grep -v "^#" | grep -v "^$"
+
       - name: Rename zmk.uf2
         run: cp build/zephyr/zmk.uf2 cradio_right_nice_nano_v2.uf2
+
       - name: Archive (Cradio/Sweep Right)
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
### Issue

Forking this repo results in a few warning annotations on the `Build` workflow:

```
4 warnings

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

### Fix
This PR gets rid of those warnings by upgrading to upgrading the GitHub actions from v2 to v3 (checkout, cache, upload-artifact).

### Correctness
Comparing the produced asset from [v2](https://github.com/22a/zmk-sweep/actions/runs/4139110586) and [v3](https://github.com/22a/zmk-sweep/actions/runs/4139143290) they're the same size on disk after extraction and behave the same on my sweep.

```
$ ls -la v2
total 968
drwxrwxrwx 1 peter peter   4096 Feb  9 23:05 .
drwxrwxrwx 1 peter peter   4096 Feb  9 23:05 ..
-rwxrwxrwx 1 peter peter 400896 Feb  9 23:05 cradio_left_nice_nano_v2.uf2
-rwxrwxrwx 1 peter peter 313856 Feb  9 23:05 cradio_right_nice_nano_v2.uf2
-rwxrwxrwx 1 peter peter 270581 Feb  9 23:04 firmware-zmk-sweep.zip
$ ls -la v3
total 968
drwxrwxrwx 1 peter peter   4096 Feb  9 23:05 .
drwxrwxrwx 1 peter peter   4096 Feb  9 23:05 ..
-rwxrwxrwx 1 peter peter 400896 Feb  9 23:05 cradio_left_nice_nano_v2.uf2
-rwxrwxrwx 1 peter peter 313856 Feb  9 23:05 cradio_right_nice_nano_v2.uf2
-rwxrwxrwx 1 peter peter 270577 Feb  9 23:05 firmware-zmk-sweep.zip
```